### PR TITLE
Update match pattern to support chat again.

### DIFF
--- a/chatgpt_tampermonkey_user_script.js
+++ b/chatgpt_tampermonkey_user_script.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        ChatGPT: Parse q parameter to input
 // @description Query ChatGPT from Alfred.
-// @match       https://chat.openai.com/chat*
+// @match       https://chat.openai.com/*
 // @grant       none
 // @version     1.0
 // ==/UserScript==


### PR DESCRIPTION
OpenAI seems to have removed the /chat path.
With this change, the script works again.